### PR TITLE
Update installing songs page to point to the r2modman page and video tutorial

### DIFF
--- a/docs/user-guide/installation/installing-songs.md
+++ b/docs/user-guide/installation/installing-songs.md
@@ -1,8 +1,8 @@
 # Installing Songs
 ---
-?> If you prefer video tutorials, VorgunTheBeta has [a video explaining how to install mods and custom songs](https://youtu.be/pSwNSGx-P5c).
+?> If you prefer video tutorials, Rayanne has [a video explaining how to install mods and custom songs](https://youtu.be/6msFI8Sz1UQ).
 
-!> **IMPORTANT:** Make sure you've followed the [mod installation guide](installing-mods) to install BepInEx and TrombLoader before continuing!
+!> **IMPORTANT:** Make sure you've followed the [mod installation guide](installing-r2modman) to install BepInEx and TrombLoader before continuing!
 
 ## Finding Songs
 


### PR DESCRIPTION
Should hopefully avoid any confusion, although we may need to update the screenshots too.

I'm wondering if we should get rid of this page entirely, and instead just incorporate things into each platform's installing mods guides.